### PR TITLE
Add a cache for getPublicSuffix as psl.get is very CPU intensive

### DIFF
--- a/lib/pubsuffix-psl.js
+++ b/lib/pubsuffix-psl.js
@@ -31,8 +31,15 @@
 'use strict';
 var psl = require('psl');
 
+var publicSuffixCache = {};
+
 function getPublicSuffix(domain) {
-  return psl.get(domain);
+  if(publicSuffixCache[domain] === undefined) {
+    publicSuffixCache[domain] = psl.get(domain);
+  }
+
+  return publicSuffixCache[domain];
 }
 
 exports.getPublicSuffix = getPublicSuffix;
+exports.publicSuffixCache = publicSuffixCache;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "RFC6265",
     "RFC2965"
   ],
-  "version": "3.0.1",
+  "version": "3.0.1-add-psl-get-cache",
   "homepage": "https://github.com/salesforce/tough-cookie",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of an effort to improve load generation throughput from https://github.com/artilleryio/artillery/ 